### PR TITLE
Properties edited after having sent the first save message are not actually saved to the db

### DIFF
--- a/iActiveRecord/ActiveRecord.m
+++ b/iActiveRecord/ActiveRecord.m
@@ -180,14 +180,24 @@ static NSString *registerHasManyThrough = @"_ar_registerHasManyThrough";
     if(nil != self){
         self.updatedAt = [NSDate dateWithTimeIntervalSinceNow:0];
         self.createdAt = [NSDate dateWithTimeIntervalSinceNow:0];
+		for (ARColumn* column in self.columns) {
+			[self addObserver:self forKeyPath:column.columnName options:0 context:nil];
+		}
     }
     return self;    
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context{
+	[self didChangeField:keyPath];
 }
 
 - (void)dealloc {
     self.id = nil;
     [errors release];
     [changedFields release];
+	for (ARColumn* column in self.columns) {
+		[self removeObserver:self forKeyPath:column.columnName];
+	}
     [super dealloc];
 }
 
@@ -207,10 +217,12 @@ static NSString *registerHasManyThrough = @"_ar_registerHasManyThrough";
     [changedFields addObject:aField];
 }
 
+/*
 - (void)setValue:(id)value forKey:(NSString *)key {
     [self didChangeField:key];
     [super setValue:value forKey:key];
 }
+*/
 
 + (void)initIgnoredFields {
 }


### PR DESCRIPTION
The code for keeping track of the edited fields of an object wasn't called if they were changed through the default synthesized setters, but only when calling the setValue:forKey: method. 
This caused the property changes to be serialized only at the first call of the save method, when all the fields are marked as edited.
I added a KVO observer for each column of an ActiveRecord object and commented out the now redundant setValue:ForKey: override.
