### PR TITLE
Fixes belonsg -> belongs typo in macro

### DIFF
--- a/iActiveRecord/ARRelationshipsHelper.h
+++ b/iActiveRecord/ARRelationshipsHelper.h
@@ -10,7 +10,7 @@
 
 #import <objc/runtime.h>
 
-#define belonsg_to_imp(class, getter, dependency) \
+#define belongs_to_imp(class, getter, dependency) \
     + (ARDependency)_ar_registerBelongsTo##class {\
         return dependency;\
     }\

--- a/iActiveRecord/TestSources/Issue.m
+++ b/iActiveRecord/TestSources/Issue.m
@@ -13,6 +13,6 @@
 @dynamic projectId;
 @dynamic title;
 
-belonsg_to_imp(Project, project, ARDependencyNullify)
+belongs_to_imp(Project, project, ARDependencyNullify)
 
 @end

--- a/iActiveRecord/TestSources/User.m
+++ b/iActiveRecord/TestSources/User.m
@@ -15,7 +15,7 @@
 
 @dynamic imageData;
 
-belonsg_to_imp(Group, group, ARDependencyDestroy)
+belongs_to_imp(Group, group, ARDependencyDestroy)
 has_many_through_imp(Project, UserProjectRelationship, projects, ARDependencyDestroy)
 
 validation_do(


### PR DESCRIPTION
A small typo in the macro that cost me a few minutes of debugging :-) Fixed in both ARRelationshipsHelper.h and TestSources/Issue.m, TestSources/User.m.
