### PR TITLE
Fix NSDecimalNumber precision loss on save

### DIFF
--- a/iActiveRecord/Classes/ARDatabaseManager.m
+++ b/iActiveRecord/Classes/ARDatabaseManager.m
@@ -509,10 +509,12 @@ static NSArray *records = nil;
                         sqlite3_bind_text(stmt, columnIndex, [value UTF8String], -1, SQLITE_TRANSIENT);
                     } else if ([value isKindOfClass:[NSDate class]]) {
                         sqlite3_bind_double(stmt, columnIndex, [value timeIntervalSince1970]);
+                    } else if ([value isKindOfClass:[NSDecimalNumber class]]) {
+                        sqlite3_bind_text(stmt, columnIndex, [[value toSql] UTF8String], -1, SQLITE_TRANSIENT);
+                    //NOTE: NSNumber must come after NSDecimalNumber because NSDecimalNumber is a
+                        //subclass of NSNumber
                     } else if ([value isKindOfClass:[NSNumber class]]) {
                         sqlite3_bind_int(stmt, columnIndex, [value integerValue]);
-                    } else if ([value isKindOfClass:[NSDecimalNumber class]]) {
-                        sqlite3_bind_double(stmt, columnIndex, [value doubleValue]);
                     } else if ([value isKindOfClass:[NSData class]]) {
                         NSData *data = value;
                         sqlite3_bind_blob(stmt, columnIndex, [data bytes], [data length], NULL);

--- a/iActiveRecord/Classes/NSDecimalNumber+sqlRepresentation.m
+++ b/iActiveRecord/Classes/NSDecimalNumber+sqlRepresentation.m
@@ -24,7 +24,7 @@
 }
 
 + (NSString *)sqlType {
-    return @"real";
+    return @"text";
 }
 
 + (id)fromSql:(NSString *)sqlData {


### PR DESCRIPTION
this commit fixes #30

Save NSDecimalNumber as text in sqlite. NSDecimalNumber is designed to do math with currencies and forces base-10 math, which gets lost if it is saved as a real in sqlite. Now passes the decimal number test spec.
