### PR TITLE
Using stringWithFormat instead of appendFormat to fix issue #50

### DIFF
--- a/iActiveRecord/Classes/ARLazyFetcher.m
+++ b/iActiveRecord/Classes/ARLazyFetcher.m
@@ -349,9 +349,9 @@
                                                arguments:data.mutableBytes];
 
     if (!self.whereStatement) {
-        self.whereStatement = [NSMutableString stringWithString:result];
+        self.whereStatement = [[NSMutableString alloc] initWithString:result];
     } else {
-        [self.whereStatement appendFormat:@"AND %@", result];
+        self.whereStatement = [NSMutableString stringWithFormat:@"%@AND %@", self.whereStatement, result];
     }
     return self;
 }


### PR DESCRIPTION
Using stringWithFormat instead of appendFormat to fix issue #50

Maybe we should change all mutable strings to normal strings and use string with format, but it may lower the performance.
