### PR TITLE
fixed NSDate column issue returning only numbers when NSDate instances are expected

### DIFF
--- a/iActiveRecord/Classes/Core/Columns/ConcreteColumns/NSDateColumn.mm
+++ b/iActiveRecord/Classes/Core/Columns/ConcreteColumns/NSDateColumn.mm
@@ -25,7 +25,7 @@ namespace AR {
 
     NSDate *__strong NSDateColumn::toColumnType(id value) const
     {
-        return value;
+        return [NSDate dateWithTimeIntervalSince1970: [value doubleValue]];
     }
 
     id NSDateColumn::toObjCObject(NSDate *value) const


### PR DESCRIPTION
changed toColumnType of the NSDateColumn to return NSDate instances instead of NSNumber values with the time interval
