### PR TITLE
 * fix issue with incorrect encoding of joined record text columns

### DIFF
--- a/iActiveRecord/Classes/DatabaseManager/ARDatabaseManager.mm
+++ b/iActiveRecord/Classes/DatabaseManager/ARDatabaseManager.mm
@@ -353,7 +353,7 @@ static NSArray *records = nil;
                                                length:sqlite3_column_bytes(statement, columnIndex)];
                     } break;
                     case SQLITE3_TEXT: {
-                        value = [NSString stringWithFormat:@"%s", sqlite3_column_text(statement, columnIndex)];
+                        value = [[NSString alloc] initWithUTF8String:(const char *) sqlite3_column_text(statement, columnIndex)];
                         if ([column.columnClass isSubclassOfClass:[NSDecimalNumber class]]) {
                             value = [NSDecimalNumber decimalNumberWithString:value];
                         }


### PR DESCRIPTION
There was a problem with the encoding of record columns that have been fetched using joins. Fixed this by duplicating the string conversion code of the non joined records
