### PR TITLE
 * enabled usage of database views as base for an active record object

### DIFF
--- a/iActiveRecord/Classes/DatabaseManager/ARDatabaseManager.h
+++ b/iActiveRecord/Classes/DatabaseManager/ARDatabaseManager.h
@@ -31,6 +31,7 @@
 - (void)closeConnection;
 
 - (NSArray *)tables;
+- (NSArray *)views;
 - (NSArray *)columnsForTable:(NSString *)aTableName;
 
 - (NSString *)tableName:(NSString *)modelName;


### PR DESCRIPTION
i added some code for handling the different format of column names that is delivered by sqlite3 function if the underlying database table of an ActiveRecord class is a database view.

The code should usually not have any other effect, since the column is not null with normal dabase tables  
