### PR TITLE
Fix issue on date format storage (From float to double)

### DIFF
--- a/iActiveRecord/Classes/NSDate+sqlRepresentation.m
+++ b/iActiveRecord/Classes/NSDate+sqlRepresentation.m
@@ -12,7 +12,7 @@
 
 - (NSString *)toSql {
     NSTimeInterval time = [self timeIntervalSince1970];
-    return [NSString stringWithFormat:@"%f", time];
+    return @(time).stringValue;
 }
 
 + (id)fromSql:(NSString *)sqlData {


### PR DESCRIPTION
Fixed issue on date storage. 
NSTimestamp is a double, so if you cast it into float, you are loosing some precision resulting 50 seconds between before storage and after.
